### PR TITLE
wire: menu option 2 uses QueryService; add QueryService + tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- JSON parsing -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -40,6 +47,7 @@
                 <version>3.2.5</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <argLine>-Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,34 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <!-- Junit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/cody/sprintcli/ApiClient.java
+++ b/src/main/java/com/cody/sprintcli/ApiClient.java
@@ -1,111 +1,89 @@
 package com.cody.sprintcli;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ApiClient {
+    private final ApiConfig config;
 
-    public static String getAirportsByCity(int cityId) {
-        try {
-            String endpointUrl = "http://localhost:8080/api/cities/" + cityId + "/airports";
-            URL url = new URL(endpointUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
+    public ApiClient(ApiConfig config) {
+        this.config = config;
+    }
 
-            // Read the response
-            BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(connection.getInputStream())
-            );
-            StringBuilder response = new StringBuilder();
-            String line;
+    /** Generic GET that all helpers use. Throws on non-2xx with status/snippet. */
+    public String get(String path, Map<String,String> queryParams) throws IOException {
+        URL url = buildUrl(path, queryParams);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Accept", "application/json");
+        conn.setConnectTimeout(config.getConnectTimeoutMs());
+        conn.setReadTimeout(config.getReadTimeoutMs());
 
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
+        int code = conn.getResponseCode();
+        InputStream stream = (code >= 200 && code < 300) ? conn.getInputStream() : conn.getErrorStream();
+        String body = readBody(stream);
+        conn.disconnect();
 
-            reader.close();
-            connection.disconnect();
-
-            return response.toString(); // this is the raw JSON response
-        } catch (Exception e) {
-            return "Error fetching data: " + e.getMessage();
+        if (code >= 200 && code < 300) {
+            return body == null ? "" : body;
+        } else {
+            String snippet = (body == null) ? "" : (body.length() > 300 ? body.substring(0, 300) + "..." : body);
+            throw new IOException("HTTP " + code + " GET " + url + (snippet.isEmpty() ? "" : " — " + snippet));
         }
     }
 
-    public static String getAircraftByPassenger(int passengerId) {
-        try {
-            String endpointUrl = "http://localhost:8080/api/passengers/" + passengerId + "/aircraft";
-            URL url = new URL(endpointUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
+    private URL buildUrl(String path, Map<String,String> query) throws MalformedURLException {
+        String base = config.getBaseUrl();
+        StringBuilder sb = new StringBuilder();
+        if (base.endsWith("/") && path.startsWith("/")) {
+            sb.append(base, 0, base.length() - 1).append(path);
+        } else if (!base.endsWith("/") && !path.startsWith("/")) {
+            sb.append(base).append("/").append(path);
+        } else {
+            sb.append(base).append(path);
+        }
+        if (query != null && !query.isEmpty()) {
+            sb.append('?').append(query.entrySet().stream()
+                    .map(e -> enc(e.getKey()) + "=" + enc(e.getValue()))
+                    .collect(Collectors.joining("&")));
+        }
+        return new URL(sb.toString());
+    }
 
-            BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(connection.getInputStream())
-            );
-            StringBuilder response = new StringBuilder();
-            String line;
+    private static String enc(String s) {
+        try { return URLEncoder.encode(s, StandardCharsets.UTF_8.toString()); }
+        catch (Exception e) { return s; }
+    }
 
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
-
-            reader.close();
-            connection.disconnect();
-
-            return response.toString();
-
-        } catch (Exception e) {
-            return "Error fetching data: " + e.getMessage();
+    private static String readBody(InputStream in) throws IOException {
+        if (in == null) return "";
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder(); String line;
+            while ((line = br.readLine()) != null) sb.append(line);
+            return sb.toString();
         }
     }
 
-    public static String getAirportsUsedByPassenger(int passengerId) {
-        try {
-            String endpointUrl = "http://localhost:8080/api/passengers/" + passengerId + "/airports";
-            URL url = new URL(endpointUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-
-            BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            StringBuilder response = new StringBuilder();
-            String line;
-
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
-
-            reader.close();
-            connection.disconnect();
-
-            return response.toString();
-        } catch (Exception e) {
-            return "Error fetching data: " + e.getMessage();
-        }
+    // wrappers (instance methods, no hardcoded base URL)
+    public String getAirportsByCity(int cityId) throws java.io.IOException {
+        return get("/api/cities/" + cityId + "/airports", java.util.Map.of());
     }
-
-    public static String getAirportsForAircraft(int aircraftId) {
-        try {
-            String endpointUrl = "http://localhost:8080/api/aircraft/" + aircraftId + "/airports";
-            URL url = new URL(endpointUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-
-            BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            StringBuilder response = new StringBuilder();
-            String line;
-
-            while ((line = reader.readLine()) != null) {
-                response.append(line);
-            }
-
-            reader.close();
-            connection.disconnect();
-
-            return response.toString();
-        } catch (Exception e) {
-            return "Error fetching data: " + e.getMessage();
-        }
+    public String getAircraftByPassenger(int passengerId) throws java.io.IOException {
+        return get("/api/passengers/" + passengerId + "/aircraft", java.util.Map.of());
+    }
+    public String getAirportsUsedByPassenger(int passengerId) throws java.io.IOException {
+        return get("/api/passengers/" + passengerId + "/airports", java.util.Map.of());
+    }
+    public String getAirportsForAircraft(int aircraftId) throws java.io.IOException {
+        return get("/api/aircraft/" + aircraftId + "/airports", java.util.Map.of());
     }
 }

--- a/src/main/java/com/cody/sprintcli/ApiConfig.java
+++ b/src/main/java/com/cody/sprintcli/ApiConfig.java
@@ -14,22 +14,28 @@ public class ApiConfig {
     public String getBaseUrl() {
         return baseUrl;
     }
-    public int getConnectTimeoutMs(){
+
+    public int getConnectTimeoutMs() {
         return connectTimeoutMs;
     }
+
     public int getReadTimeoutMs() {
         return readTimeoutMs;
     }
 
-    private static String getenvOrDefault(String key, String def) {
+    /** Return env var value or default if missing/blank */
+    static String getenvOrDefault(String key, String def) {
         String envValue = System.getenv(key);
-        return (envValue == null || envValue.isBlank()) ? def : envValue;
+        return (envValue == null || envValue.isBlank()) ? def : envValue.trim();
     }
-    private static int parseIntEnv(String key, int def) {
+
+    /** Parse integer env var or fall back to default */
+    static int parseIntEnv(String key, int def) {
+        String envValue = System.getenv(key);
+        if (envValue == null || envValue.isBlank()) return def;
         try {
-            String envValue = System.getenv(key);
-            return (envValue == null || envValue.isBlank()) ? def : Integer.parseInt(envValue.trim());
-        } catch (NumberFormatException e){
+            return Integer.parseInt(envValue.trim());
+        } catch (NumberFormatException e) {
             return def;
         }
     }

--- a/src/main/java/com/cody/sprintcli/ApiConfig.java
+++ b/src/main/java/com/cody/sprintcli/ApiConfig.java
@@ -1,12 +1,12 @@
 package com.cody.sprintcli;
 
 public class ApiConfig {
-    private final Stirng baseUrl;
+    private final String baseUrl;
     private final int connectTimeoutMs;
     private final int readTimeoutMs;
 
     public ApiConfig() {
-        this.baseUrl = getenvOrDefulat("API_BASE_URL", "HTTP://localhost:8080");
+        this.baseUrl = getenvOrDefault("API_BASE_URL", "http://localhost:8080");
         this.connectTimeoutMs = parseIntEnv("API_CONNECT_TIMEOUT_MS", 5000);
         this.readTimeoutMs = parseIntEnv("API_READ_TIMEOUT_MS", 8000);
     }
@@ -18,7 +18,7 @@ public class ApiConfig {
         return connectTimeoutMs;
     }
     public int getReadTimeoutMs() {
-        return getReadTimeoutMs;
+        return readTimeoutMs;
     }
 
     private static String getenvOrDefault(String key, String def) {

--- a/src/main/java/com/cody/sprintcli/App.java
+++ b/src/main/java/com/cody/sprintcli/App.java
@@ -1,63 +1,94 @@
 package com.cody.sprintcli;
 
+import java.io.IOException;
 import java.util.Scanner;
 
 public class App {
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
-        boolean running = true;
+        ApiClient client = new ApiClient(new ApiConfig());
+        QueryService service = new QueryService(client);
 
+        boolean running = true;
         while (running) {
             printMenu();
-
             System.out.print("Enter your choice (1–5): ");
-            int choice = scanner.nextInt();
 
-            switch (choice) {
-                case 1:
-                    System.out.print("Enter City ID: ");
-                    int cityId = scanner.nextInt();
-                    System.out.println("Airports in City ID " + cityId + ":");
-                    System.out.println(ApiClient.getAirportsByCity(cityId));
-                    break;
+            int choice = readInt(scanner, 1, 5);
 
-                case 2:
-                    System.out.println("You chose to view aircraft flown by a passenger.");
-                    System.out.print("Enter Passenger ID: ");
-                    int passengerIdAircraft = scanner.nextInt();
-                    System.out.println("Aircraft flown by Passenger ID " + passengerIdAircraft + ":");
-                    System.out.println(ApiClient.getAircraftByPassenger(passengerIdAircraft));
-                    break;
-
-                case 3:
-                    System.out.println("You chose to view departure/arrival airports for an aircraft.");
-                    System.out.print("Enter Aircraft ID: ");
-                    int aircraftId = scanner.nextInt();
-                    System.out.println("Airports used by Aircraft ID " + aircraftId + ":");
-                    System.out.println(ApiClient.getAirportsForAircraft(aircraftId));
-                    break;
-
-                case 4:
-                    System.out.println("You chose to view airports used by a passenger.");
-                    System.out.print("Enter Passenger ID: ");
-                    int passengerIdAirport = scanner.nextInt();
-                    System.out.println("Airports used by Passenger ID " + passengerIdAirport + ":");
-                    System.out.println(ApiClient.getAirportsUsedByPassenger(passengerIdAirport));
-                    break;
-
-                case 5:
-                    System.out.println("Exiting... Goodbye!");
-                    running = false;
-                    break;
-
-                default:
-                    System.out.println("Invalid choice. Please enter a number between 1 and 5.");
+            try {
+                switch (choice) {
+                    case 1 -> {
+                        int cityId = readPositiveInt(scanner, "Enter City ID: ");
+                        System.out.println(service.airportsInCity(cityId));
+                    }
+                    case 2 -> {
+                        int passengerId = readPositiveInt(scanner, "Enter Passenger ID: ");
+                        System.out.println(service.aircraftForPassenger(passengerId));
+                    }
+                    case 3 -> {
+                        int aircraftId = readPositiveInt(scanner, "Enter Aircraft ID: ");
+                        System.out.println("Airports used by Aircraft ID " + aircraftId + ":");
+                        System.out.println(client.getAirportsForAircraft(aircraftId));
+                    }
+                    case 4 -> {
+                        int passengerId = readPositiveInt(scanner, "Enter Passenger ID: ");
+                        System.out.println("Airports used by Passenger ID " + passengerId + ":");
+                        System.out.println(client.getAirportsUsedByPassenger(passengerId));
+                    }
+                    case 5 -> {
+                        System.out.println("Exiting... Goodbye!");
+                        running = false;
+                    }
+                    default -> System.out.println("Invalid choice. Please enter a number between 1 and 5.");
+                }
+            } catch (IOException e) {
+                System.out.println("Request failed: " + e.getMessage());
             }
 
-            System.out.println(); // Add space between interactions
+            System.out.println(); // spacing
         }
 
         scanner.close();
+    }
+
+    private static int readInt(Scanner scanner, int min, int max) {
+        while (!scanner.hasNextInt()) {
+            System.out.print("Please enter a number " + min + "–" + max + ": ");
+            scanner.next(); // discard bad token
+        }
+        int value = scanner.nextInt();
+        scanner.nextLine(); // consume newline
+        while (value < min || value > max) {
+            System.out.print("Please enter a number " + min + "–" + max + ": ");
+            while (!scanner.hasNextInt()) {
+                System.out.print("Please enter a number " + min + "–" + max + ": ");
+                scanner.next();
+            }
+            value = scanner.nextInt();
+            scanner.nextLine();
+        }
+        return value;
+    }
+
+    private static int readPositiveInt(Scanner scanner, String prompt) {
+        System.out.print(prompt);
+        while (!scanner.hasNextInt()) {
+            System.out.print("Please enter a whole number: ");
+            scanner.next(); // discard bad token
+        }
+        int value = scanner.nextInt();
+        scanner.nextLine(); // consume newline
+        while (value <= 0) {
+            System.out.print("ID must be positive. Try again: ");
+            while (!scanner.hasNextInt()) {
+                System.out.print("Please enter a whole number: ");
+                scanner.next();
+            }
+            value = scanner.nextInt();
+            scanner.nextLine();
+        }
+        return value;
     }
 
     public static void printMenu() {

--- a/src/main/java/com/cody/sprintcli/QueryService.java
+++ b/src/main/java/com/cody/sprintcli/QueryService.java
@@ -1,0 +1,162 @@
+package com.cody.sprintcli;
+
+import com.cody.sprintcli.models.Airport;
+import com.cody.sprintcli.models.Aircraft;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryService {
+    private final ApiClient client;
+    private final Gson gson;
+
+    public QueryService(ApiClient client) {
+        this.client = client;
+        this.gson = new GsonBuilder().setLenient().create();
+    }
+
+    /** Q1: Airports in a city (formatted string for CLI output) */
+    public String airportsInCity(int cityId) {
+        try {
+            String json = client.getAirportsByCity(cityId);
+            List<Airport> airports = parseAirports(json);
+            if (airports.isEmpty()) {
+                return "No airports found for city ID " + cityId + ".";
+            }
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < airports.size(); i++) {
+                Airport a = airports.get(i);
+                sb.append(i + 1).append(") ")
+                        .append(a.getName() == null ? "(unnamed)" : a.getName())
+                        .append(" (").append(a.getCode() == null ? "???" : a.getCode()).append(")")
+                        .append(" [id: ").append(a.getId()).append("]")
+                        .append('\n');
+            }
+            return sb.toString().trim();
+        } catch (IOException e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage();
+            if (msg.contains("HTTP 404")) return "City not found (id " + cityId + ").";
+            return "Request failed: " + msg;
+        }
+    }
+
+    /** Q2: Aircraft flown by a passenger (formatted for CLI) */
+    public String aircraftForPassenger(int passengerId) {
+        try {
+            String json = client.getAircraftByPassenger(passengerId);
+            List<Aircraft> aircraft = parseAircraft(json);
+            if (aircraft.isEmpty()) {
+                return "No aircraft found for passenger ID " + passengerId + ".";
+            }
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < aircraft.size(); i++) {
+                Aircraft a = aircraft.get(i);
+                String label =
+                        (a.getModel() != null && !a.getModel().isBlank()) ? a.getModel()
+                                : (a.getType() != null && !a.getType().isBlank()) ? a.getType()
+                                : (a.getRegistration() != null && !a.getRegistration().isBlank()) ? a.getRegistration()
+                                : "(unnamed aircraft)";
+                sb.append(i + 1).append(") ")
+                        .append(label)
+                        .append(" [id: ").append(a.getId()).append("]");
+                if (a.getRegistration() != null && !a.getRegistration().isBlank()) {
+                    sb.append(" tail: ").append(a.getRegistration());
+                }
+                sb.append('\n');
+            }
+            return sb.toString().trim();
+        } catch (IOException e) {
+            String msg = e.getMessage() == null ? "" : e.getMessage();
+            if (msg.contains("HTTP 404")) return "Passenger not found (id " + passengerId + ").";
+            return "Request failed: " + msg;
+        }
+    }
+
+    // -------- helpers: airports --------
+
+    private List<Airport> parseAirports(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        JsonElement root = JsonParser.parseString(json);
+
+        // Case 1: plain array
+        if (root.isJsonArray()) {
+            return fromAirportArray(root.getAsJsonArray());
+        }
+
+        // Case 2: object with a list under a known key (airports/data/content/items)
+        if (root.isJsonObject()) {
+            JsonObject obj = root.getAsJsonObject();
+            for (String key : new String[]{"airports", "data", "content", "items"}) {
+                if (obj.has(key) && obj.get(key).isJsonArray()) {
+                    return fromAirportArray(obj.getAsJsonArray(key));
+                }
+            }
+            // Case 3: a single airport object
+            if (looksLikeAirport(obj)) {
+                Airport single = gson.fromJson(obj, Airport.class);
+                List<Airport> one = new ArrayList<>();
+                one.add(single);
+                return one;
+            }
+        }
+        return List.of();
+    }
+
+    private List<Airport> fromAirportArray(JsonArray arr) {
+        Type listType = new TypeToken<List<Airport>>() {}.getType();
+        return gson.fromJson(arr, listType);
+    }
+
+    private boolean looksLikeAirport(JsonObject obj) {
+        return obj.has("name") || obj.has("code") || obj.has("id");
+    }
+
+    // -------- helpers: aircraft --------
+
+    private List<Aircraft> parseAircraft(String json) {
+        if (json == null || json.isBlank()) return List.of();
+        JsonElement root = JsonParser.parseString(json);
+
+        // plain array
+        if (root.isJsonArray()) {
+            return fromAircraftArray(root.getAsJsonArray());
+        }
+
+        // wrapped array under common keys
+        if (root.isJsonObject()) {
+            JsonObject obj = root.getAsJsonObject();
+            for (String key : new String[]{"aircraft", "airplanes", "data", "content", "items"}) {
+                if (obj.has(key) && obj.get(key).isJsonArray()) {
+                    return fromAircraftArray(obj.getAsJsonArray(key));
+                }
+            }
+            // single object
+            if (looksLikeAircraft(obj)) {
+                Aircraft single = gson.fromJson(obj, Aircraft.class);
+                List<Aircraft> one = new ArrayList<>();
+                one.add(single);
+                return one;
+            }
+        }
+        return List.of();
+    }
+
+    private List<Aircraft> fromAircraftArray(JsonArray arr) {
+        Type listType = new TypeToken<List<Aircraft>>() {}.getType();
+        return gson.fromJson(arr, listType);
+    }
+
+    private boolean looksLikeAircraft(JsonObject obj) {
+        return obj.has("id") || obj.has("model") || obj.has("type") || obj.has("registration");
+    }
+}

--- a/src/main/java/com/cody/sprintcli/models/Aircraft.java
+++ b/src/main/java/com/cody/sprintcli/models/Aircraft.java
@@ -2,38 +2,42 @@ package com.cody.sprintcli.models;
 
 public class Aircraft {
     private int id;
+    private String model;
     private String type;
-    private String airlineName;
-    private int numberOfPassengers;
+    private String registration;
 
-    // Constructor
-    public Aircraft(int id, String type, String airlineName, int numberOfPassengers) {
+    // Needed by Gson
+    public Aircraft() {}
+
+    public Aircraft(int id, String model, String type, String registration) {
         this.id = id;
+        this.model = model;
         this.type = type;
-        this.airlineName = airlineName;
-        this.numberOfPassengers = numberOfPassengers;
+        this.registration = registration;
     }
 
-    // Getters
     public int getId() {
         return id;
+    }
+
+    public String getModel() {
+        return model;
     }
 
     public String getType() {
         return type;
     }
 
-    public String getAirlineName() {
-        return airlineName;
+    public String getRegistration() {
+        return registration;
     }
 
-    public int getNumberOfPassengers() {
-        return numberOfPassengers;
-    }
-
-    // toString method for clean output
     @Override
     public String toString() {
-        return type + " (" + airlineName + ") - Capacity: " + numberOfPassengers;
+        String label = (model != null && !model.isBlank()) ? model
+                : (type != null && !type.isBlank()) ? type
+                : (registration != null && !registration.isBlank()) ? registration
+                : "(unnamed aircraft)";
+        return label + " [id: " + id + (registration != null && !registration.isBlank() ? ", tail: " + registration : "") + "]";
     }
 }

--- a/src/main/java/com/cody/sprintcli/models/Airport.java
+++ b/src/main/java/com/cody/sprintcli/models/Airport.java
@@ -16,15 +16,14 @@ public class Airport {
     public int getId() {
         return id;
     }
-
     public String getName() {
         return name;
     }
-
     public String getCode() {
         return code;
     }
 
+    @Override
     public String toString() {
         return name + " (" + code + ")";
     }

--- a/src/test/java/com/cody/sprintcli/QueryServiceTest.java
+++ b/src/test/java/com/cody/sprintcli/QueryServiceTest.java
@@ -1,0 +1,93 @@
+package com.cody.sprintcli;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class QueryServiceTest {
+
+    @Test
+    void airportsInCity_formatsList_fromArrayJson() throws Exception {
+        // sample JSON
+        String json = """
+          [
+            {"id":1,"name":"St. John's International Airport","code":"YYT"},
+            {"id":2,"name":"Gander International Airport","code":"YQX"}
+          ]
+        """;
+
+        ApiClient mockClient = mock(ApiClient.class);
+        when(mockClient.getAirportsByCity(1)).thenReturn(json);
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.airportsInCity(1);
+
+        assertTrue(out.contains("1) St. John's International Airport (YYT) [id: 1]"));
+        assertTrue(out.contains("2) Gander International Airport (YQX) [id: 2]"));
+    }
+
+    @Test
+    void airportsInCity_handlesNotFound() throws Exception {
+        ApiClient mockClient = mock(ApiClient.class);
+        when(mockClient.getAirportsByCity(999))
+                .thenThrow(new java.io.IOException("HTTP 404 GET http://localhost:8080/..."));
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.airportsInCity(999);
+
+        assertEquals("City not found (id 999).", out);
+    }
+
+    @Test
+    void airportsInCity_handlesEmptyArray() throws Exception {
+        ApiClient mockClient = mock(ApiClient.class);
+        when(mockClient.getAirportsByCity(2)).thenReturn("[]");
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.airportsInCity(2);
+
+        assertEquals("No airports found for city ID 2.", out);
+    }
+
+    @org.junit.jupiter.api.Test
+    void aircraftForPassenger_formatsList_fromArrayJson() throws Exception {
+        String json = """
+      [
+        {"id":101,"model":"Boeing 737-800","registration":"C-ABCD"},
+        {"id":102,"model":"Airbus A320","registration":"C-EFGH"}
+      ]
+    """;
+
+        com.cody.sprintcli.ApiClient mockClient = org.mockito.Mockito.mock(com.cody.sprintcli.ApiClient.class);
+        org.mockito.Mockito.when(mockClient.getAircraftByPassenger(1)).thenReturn(json);
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.aircraftForPassenger(1);
+
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("1) Boeing 737-800 [id: 101] tail: C-ABCD"));
+        org.junit.jupiter.api.Assertions.assertTrue(out.contains("2) Airbus A320 [id: 102] tail: C-EFGH"));
+    }
+
+    @org.junit.jupiter.api.Test
+    void aircraftForPassenger_handlesNotFound() throws Exception {
+        com.cody.sprintcli.ApiClient mockClient = org.mockito.Mockito.mock(com.cody.sprintcli.ApiClient.class);
+        org.mockito.Mockito.when(mockClient.getAircraftByPassenger(999))
+                .thenThrow(new java.io.IOException("HTTP 404 GET http://localhost:8080/..."));
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.aircraftForPassenger(999);
+
+        org.junit.jupiter.api.Assertions.assertEquals("Passenger not found (id 999).", out);
+    }
+
+    @org.junit.jupiter.api.Test
+    void aircraftForPassenger_handlesEmptyArray() throws Exception {
+        com.cody.sprintcli.ApiClient mockClient = org.mockito.Mockito.mock(com.cody.sprintcli.ApiClient.class);
+        org.mockito.Mockito.when(mockClient.getAircraftByPassenger(2)).thenReturn("[]");
+
+        QueryService service = new QueryService(mockClient);
+        String out = service.aircraftForPassenger(2);
+
+        org.junit.jupiter.api.Assertions.assertEquals("No aircraft found for passenger ID 2.", out);
+    }
+}


### PR DESCRIPTION
### What
- Add `QueryService` to format CLI output and parse JSON.
- Refactor `App` to call `QueryService` instead of printing raw JSON.
- Add unit tests (`QueryServiceTest`) covering success/empty/404/error paths.
- Add Gson dependency for JSON parsing; configure Mockito for JDK 23.
- Improve input validation for menu choices and IDs.

### Why
- Fulfills Role 2 requirements: user-friendly CLI, test coverage, clear separation between HTTP calls and presentation.
- Makes the CLI deterministic and easier to test.

### How to test
- Run unit tests: `mvn -DskipTests=false test`
- Manual check (with backend running):  
  `java -cp target/classes:$(cat cp.txt) com.cody.sprintcli.App`

### Scope
- CLI repo only. No backend changes.

### Notes
- Requires backend (API) running locally or in the lab environment for manual testing.
